### PR TITLE
[WIP] Test of using a sphinx extension for auto-recorded examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 python:
   - "3.6"
-install: pip install sphinx
+install: pip install -r requirements.txt
 script:
   - make doctest
   - make html

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: build
+.PHONY: build clean-examples
 build: html
 
 # this pattern rule lets you run "make build" (or any other target
 # in docs/Makefile) in this directory as though you were in docs/
 %:
 	cd docs && make $@
+
+# wipe out all recorded examples
+clean-examples:
+	find docs -name _examples -type d | xargs rm -rf

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.intersphinx',
     'sphinx.ext.doctest',
+    'sphinxcontrib.autorunrecord',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -43,3 +43,11 @@ Misc
    Notes defined within all diatonic and chromatic musical scales have been
    intentionally excluded from this list of additional notes. Additionally,
    this note.
+
+Example Demo
+------------
+
+.. toctree::
+   :maxdepth: 1
+
+   remove/me

--- a/docs/remove/_examples/firstdemo
+++ b/docs/remove/_examples/firstdemo
@@ -1,0 +1,1 @@
+$ date > testfile

--- a/docs/remove/_examples/seconddemo
+++ b/docs/remove/_examples/seconddemo
@@ -1,0 +1,2 @@
+$ funky-file-viewer
+Thu 27 Jun 2019 07:23:27 PM CEST

--- a/docs/remove/me.rst
+++ b/docs/remove/me.rst
@@ -1,0 +1,16 @@
+**********************
+Test for autorunrecord
+**********************
+
+.. runrecord:: _examples/firstdemo
+   :language: console
+
+   $ date > testfile
+
+.. runrecord:: _examples/seconddemo
+   :language: console
+   :emphasize-lines: 2
+   :realcommand: cat testfile
+
+   $ funky-file-viewer
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ Sphinx
 sphinx-sitemap
 sphinxcontrib-websupport
 urllib3
+autorunrecord


### PR DESCRIPTION
This adds a new chapter "remove" to demonstrate the use of a custom sphinx extension to run arbitrary (shell) code and capture the output. The goal is to be able to auto-execute real examples, but capture and cache their output for inclusion in the book, without having to run all code at build-time.

Here is the extension:

https://github.com/mih/autorunrecord

It should be pip-installable: `pip install autorunrecord`

The rest should be automatic.

The `runrecord` directive shown in the examples can be used in the same fashion and has the same features as the `literalinclude` directive that comes with sphinx (in fact, it is based on it). In addition, however, it can auto-generate the to-be-included files based on the code given in the block. Moreover, if it is necessary (e.g. for didactic reasons) to simplify the displayed command, but a more complicated variant is needed for optimal output, such a command can be given via the `realcommand` option.

All examples in a given RST file run sequentially in a dedicated work dir, hence incremental examples are possible.

Additional features can be and will be added later, such as:

- `prep` commands that establish a particular state of a worktree, but have no rendered equivalent
- `pretest`/`posttest` option that allow for specification of arbitrary test code that can verify preconditions and expected command results -- to by able to use these examples as doctests

TODO:

- [x] figure out what is missing for travis to like this