### PR TITLE
Foldable sections on pages

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,12 @@
+.toggle .header {
+    display: block;
+    clear: both;
+}
+
+.toggle .header:after {
+    content: " ▶";
+}
+
+.toggle .header.open:after {
+    content: " ▼";
+}

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,0 +1,14 @@
+{% extends "!page.html" %}
+
+{% block footer %}
+ <script type="text/javascript">
+    $(document).ready(function() {
+        $(".toggle > *").hide();
+        $(".toggle .header").show();
+        $(".toggle .header").click(function() {
+            $(this).parent().children().not(".header").toggle(400);
+            $(this).parent().children(".header").toggleClass("open");
+        })
+    });
+</script>
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -285,3 +285,6 @@ todo_include_todos = True
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
 }
+
+def setup(app):
+    app.add_stylesheet('custom.css')

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -52,3 +52,4 @@ Example Demo
    :maxdepth: 1
 
    remove/me
+   remove/metoo

--- a/docs/remove/metoo.rst
+++ b/docs/remove/metoo.rst
@@ -1,0 +1,22 @@
+#########################
+Test for folding sections
+#########################
+
+Here we have a very basic command:
+
+.. code-block:: bash
+
+   % datalad create firstrepo
+
+There are many advanced options, and if I put them all
+on this page, it will look very very complicated.
+
+.. container:: toggle
+
+    .. container:: header
+
+        **Click here to show how to attach a description**
+
+    .. code-block:: bash
+
+       % datalad create firstrepo --description "This is my first repo"


### PR DESCRIPTION
Upfront: I followed advice from someone on the internet, and I'm not sure whether what I'm doing could interfere with other things. Maybe @mih can have a look at this.

When writing sections I'm torn between keeping everything simple and short, and including very useful, but more advanced information that would make the content of a page appear more complex than it actually is. Such more advanced options would fit content-wise, and would be helpful for readers that want to learn more or are already more proficient, but could be intimidating, frustrating or needlessly complex for very new users.

One potential solution I thought about is having folded sections that one can unfold on demand (a bit like the ``<details> </details>`` functions in Github markdown). With this PR, I'm trying to implement this.

There is a test/example for this in ``remove/metoo`` and its included in the ``Example demo`` section. 